### PR TITLE
Reject the promise when there is an error

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -98,7 +98,10 @@ exports = module.exports = function(options, buildResult) {
 	.then(function(){
 		return buildApp();
 	})
-	.then(restoreHTML, restoreHTML);
+	.then(restoreHTML, function(err){
+		restoreHTML();
+		return Promise.reject(err);
+	});
 };
 
 // This exists so we can stub it in tests

--- a/test/test.js
+++ b/test/test.js
@@ -7,54 +7,91 @@ var stealElectron = require("../lib/main");
 var cheerio = require("cheerio");
 
 describe("steal-electron", function(){
-	before(function(done){
-		this.timeout(30000);
+	describe("A normal application", function(){
+		before(function(done){
+			helpers.rmdir(__dirname + "/build")
+			.then(function(){
+				var electronOptions = {
+					buildDir: './build',
+					platforms: ['darwin'],
+					files: ["dist/**/*", "production.html"]
+				};
 
-		helpers.rmdir(__dirname + "/build")
-		.then(function(){
-			var electronOptions = {
-				buildDir: './build',
-				platforms: ['darwin'],
-				files: ["dist/**/*", "production.html"]
-			};
+				var buildResult = {
+					configuration: {
+						dest: __dirname + "/tests/app/dist"
+					},
+					loader: {
+						baseURL: __dirname + "/tests/app"
+					}
+				};
 
-			var buildResult = {
-				configuration: {
-					dest: __dirname + "/tests/app/dist"
-				},
-				loader: {
-					baseURL: __dirname + "/tests/app"
-				}
-			};
+				helpers.stubExportPackager(stealElectron, buildResult);
 
-			helpers.stubExportPackager(stealElectron, buildResult);
+				var fin = function() { done(); }
+				stealElectron(electronOptions, buildResult).then(fin, done);
+			});
+		});
 
-			var fin = function() { done(); }
-			stealElectron(electronOptions, buildResult).then(fin, done);
+		after(function(done){
+			var fin = function() { done(); };
+			helpers.rmdir(__dirname + "/tests/app/build")
+			.then(fin, done);
+		});
+
+		it("Copies over the production files", function(){
+			assert(exists(__dirname + "/tests/app/build/test/tests/app/production.html"));
+		});
+
+		it("Adds env=electron-production to the steal script tag", function(){
+			var src = readFile(__dirname + "/tests/app/build/test/tests/app/production.html");
+			var $ = cheerio.load(src);
+			var env = $("script").attr("env");
+			assert.equal(env, "electron-production", "The env attr was added");
+		});
+
+		it("The original main html doesn't have env=electron-production", function(){
+			var src = readFile(__dirname + "/tests/app/production.html");
+			var $ = cheerio.load(src);
+			var env = $("script").attr("env");
+			assert.equal(env, undefined, "There is no env attr");
 		});
 	});
 
-	after(function(done){
-		var fin = function() { done(); };
-		helpers.rmdir(__dirname + "/tests/app/build")
-		.then(fin, done);
-	});
+	describe("An app that doesn't exist", function(){
+		before(function(done){
+			helpers.rmdir(__dirname + "/build")
+			.then(function(){
+				var electronOptions = {
+					buildDir: './build',
+					platforms: ['darwin'],
+					files: ["dist/**/*", "production.html"]
+				};
 
-	it("Copies over the production files", function(){
-		assert(exists(__dirname + "/tests/app/build/test/tests/app/production.html"));
-	});
+				var buildResult = {
+					configuration: {
+						dest: __dirname + "/tests/fake-app/dist"
+					},
+					loader: {
+						baseURL: __dirname + "/tests/fake-app"
+					}
+				};
 
-	it("Adds env=electron-production to the steal script tag", function(){
-		var src = readFile(__dirname + "/tests/app/build/test/tests/app/production.html");
-		var $ = cheerio.load(src);
-		var env = $("script").attr("env");
-		assert.equal(env, "electron-production", "The env attr was added");
-	});
+				helpers.stubExportPackager(stealElectron, buildResult);
 
-	it("The original main html doesn't have env=electron-production", function(){
-		var src = readFile(__dirname + "/tests/app/production.html");
-		var $ = cheerio.load(src);
-		var env = $("script").attr("env");
-		assert.equal(env, undefined, "There is no env attr");
+				var fin = function() { done(); }
+				stealElectron(electronOptions, buildResult).then(fin)
+				.then(null, function(error){
+					this.buildError = error;
+					done();
+				}.bind(this));
+			}.bind(this));
+		});
+
+		it("Returned an error", function(){
+			var error = this.buildError;
+			assert.ok(error, "There was an error");
+			assert.equal(error instanceof Error, true, "is an error");
+		});
 	});
 });


### PR DESCRIPTION
When an error occurs we should return the Promise created when running
steal-electron.

Fixes #3