### PR TITLE
Allow specifying an alternative HTML page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ demo/dist/
 test/tests/app/dist/
 .idea/
 .DS_Store
+npm-debug.log

--- a/lib/html-rewriter.js
+++ b/lib/html-rewriter.js
@@ -11,6 +11,7 @@ function HTMLRewriter(options){
 	this.options = options;
 
 	this.root = options.cwd || process.cwd();
+	this.indexPage = options.indexPage || "production.html";
 
 	this.restore = this.restore.bind(this);
 }
@@ -68,8 +69,7 @@ HTMLRewriter.prototype = {
 	},
 
 	findHTML: function(){
-		// For now keep it simple
-		return path.join(this.root, "production.html");
+		return path.join(this.root, this.indexPage);
 	}
 };
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -9,7 +9,8 @@ exports = module.exports = function(options, buildResult) {
 	}
 
 	var rewriter = new HTMLRewriter({
-		cwd: root()
+		cwd: root(),
+		indexPage: options.indexPage
 	});
 	var rewritePromise = rewriter.rewrite();
 

--- a/test/test.js
+++ b/test/test.js
@@ -50,6 +50,28 @@ describe("steal-electron", function(){
 		});
 	});
 
+	describe("An app with an alternative HTML file", function(){
+		helpers.setup(__dirname + "/tests/app", function(options){
+			var idx = options.files.indexOf("production");
+			options.files.splice(idx, 1, "other-production.html");
+			options.indexPage = "other-production.html";
+		});
+
+		it("Copies over the correct production HTML", function(){
+			assert(!exists(__dirname + "/tests/app/build/test/tests/app/production.html"),
+				"Didn't copy over the wrong HTML file");
+			assert(exists(__dirname + "/tests/app/build/test/tests/app/other-production.html"),
+				"Did copy over the right HTML file");
+		});
+
+		it("Adds env=electron-production to the steal script tag", function(){
+			var src = readFile(__dirname + "/tests/app/build/test/tests/app/other-production.html");
+			var $ = cheerio.load(src);
+			var env = $("script").attr("env");
+			assert.equal(env, "electron-production", "The env attr was added");
+		});
+	});
+
 	describe("An app that doesn't exist", function(){
 		before(function(done){
 			helpers.rmdir(__dirname + "/build")

--- a/test/tests/app/other-production.html
+++ b/test/tests/app/other-production.html
@@ -1,0 +1,1 @@
+<script src="./dist/steal.production.js"></script>


### PR DESCRIPTION
This allows to specify an alternative index page using the
`electronOptions.indexPage` option.

Closes #9